### PR TITLE
Fixed margins on mobile and tablet

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -27,6 +27,20 @@ a:hover
   zoom: 1;
 
 }
+
+@media (min-width: 768px) and (max-width: 991.98px) {
+	.second {
+		margin: 35px 0 35px 0;
+	}
+}
+
+
+@media (max-width: 768px) {
+	.second {
+		margin: 20px 0 20px 0;
+	}
+}
+
 .level1{
 	/* margin-left: 30px; */
 }

--- a/index.html
+++ b/index.html
@@ -13,8 +13,8 @@
 <body>
 	<div class="container-fluid">
 		<div class="row">
-			<div class="col-sm-2"></div>
-			<div class="col-sm-8 ">
+			<div class="col-sm-1 col-md-1 col-lg-2"></div>
+			<div class="col-12 col-sm-10 col-md-10 col-lg-8">
 				<div class="second effect2">
 					<div class="level1">
 						<span >var </span>
@@ -245,7 +245,7 @@
 					</div>
 				</div>
 			</div>
-			<div class="col-sm-2 first"></div>
+			<div class="col-sm-1 col-md-1 col-lg-2 first"></div>
 		</div>
 
 	</div>


### PR DESCRIPTION
Hi, these changes improve the layout on small screens (mobile) and medium screens (tablet).

| Mobile before | Mobile after |
|-----------------|---------------|
| ![mobile_before](https://user-images.githubusercontent.com/13767301/154350550-31e1a37e-b53d-4813-9543-8895196eac78.png) | ![mobile_after](https://user-images.githubusercontent.com/13767301/154350840-048b5bec-8826-4991-9c6e-20252d386182.png) |

| Tablet before | Tablet after |
|----------------|-------------|
| ![tablet_before](https://user-images.githubusercontent.com/13767301/154350896-9863b23e-073f-4058-b7d9-9da7037aded0.png) | ![tablet_after](https://user-images.githubusercontent.com/13767301/154350967-65ced065-e151-4efb-9a9c-83cf37476eef.png) |


